### PR TITLE
Fixed typographical error, changed architechture to architecture in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ In Third, an execution token is a pointer to the word's machine code
 (a colon definition xt is a pointer to a CALL instruction).
 
 seg and ofs items are used by Third's far memory operators to make
-use of the Intel segment and offset architechture.
+use of the Intel segment and offset architecture.
 
 An I/O result (used mainly by FILE words) is zero if the operation
 was successful. If the operation was not successful, the ior is an


### PR DESCRIPTION
@benhoyt, I've corrected a typographical error in the documentation of the [third](https://github.com/benhoyt/third) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
